### PR TITLE
New public method LayerGroup.pm.layerChanged()

### DIFF
--- a/src/js/L.PM.LayerGroup.js
+++ b/src/js/L.PM.LayerGroup.js
@@ -3,7 +3,16 @@ L.PM.Edit.LayerGroup = L.Class.extend({
     initialize: function(layerGroup) {
         var self = this;
         this._layerGroup = layerGroup;
-        this._layers = layerGroup.getLayers();
+        this.layerChanged();
+    },
+    layerChanged: function() {
+        if (this._layers) {
+          for(var i=0; i<this._layers.length; i++) {
+              this._layers[i].off('pm:edit', this._fireEdit);
+          }
+        }
+            
+        this._layers = this._layerGroup.getLayers();
 
         for(var i=0; i<this._layers.length; i++) {
             this._layers[i].on('pm:edit', this._fireEdit, this);


### PR DESCRIPTION
This fixes #33. After new layer contents is added, calling `geoJsonLayer.pm.layerChanged()` resolves the issue