### PR TITLE
Now makes sure .pm is avaible before invoking.

### DIFF
--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -37,8 +37,10 @@ L.PM.Draw.Line = L.PM.Draw.extend({
         // fire drawstart event
         this._map.fire('pm:drawstart', { shape: this._shape });
 
-        // toggle the draw button of the Toolbar in case drawing mode got enabled without the button
-        this._map.pm.Toolbar.toggleButton(this.toolbarButtonName, true);
+        if (this._map.pm) {
+            // toggle the draw button of the Toolbar in case drawing mode got enabled without the button
+            this._map.pm.Toolbar.toggleButton(this.toolbarButtonName, true);
+        }
     },
     disable() {
         // disable draw mode
@@ -63,8 +65,10 @@ L.PM.Draw.Line = L.PM.Draw.extend({
         // fire drawend event
         this._map.fire('pm:drawend', { shape: this._shape });
 
-        // toggle the draw button of the Toolbar in case drawing mode got disabled without the button
-        this._map.pm.Toolbar.toggleButton(this.toolbarButtonName, false);
+        if (this._map.pm) {
+            // toggle the draw button of the Toolbar in case drawing mode got disabled without the button
+            this._map.pm.Toolbar.toggleButton(this.toolbarButtonName, false);
+        }
     },
     enabled() {
         return this._enabled;

--- a/src/js/Edit/L.PM.Edit.LayerGroup.js
+++ b/src/js/Edit/L.PM.Edit.LayerGroup.js
@@ -24,8 +24,10 @@ L.PM.Edit.LayerGroup = L.Class.extend({
                 layer.on(event, this._fireEvent, this);
             });
 
-            // add reference for the group to each layer inside said group
-            layer.pm._layerGroup = this._layerGroup;
+            if (layer.pm) {
+                // add reference for the group to each layer inside said group
+                layer.pm._layerGroup = this._layerGroup;
+            }
         });
 
 
@@ -37,7 +39,7 @@ L.PM.Edit.LayerGroup = L.Class.extend({
 
             // if editing was already enabled for this group, enable it again
             // so the new layers are enabled
-            if(e.target.pm.enabled()) {
+            if (e.target.pm && e.target.pm.enabled()) {
                 this.enable(this.getOptions());
             }
         });
@@ -48,26 +50,32 @@ L.PM.Edit.LayerGroup = L.Class.extend({
     toggleEdit(options) {
         this._options = options;
         this._layers.forEach((layer) => {
-            layer.pm.toggleEdit(options);
+            if (layer.pm) {
+                layer.pm.toggleEdit(options);
+            }
         });
     },
     enable(options) {
         this._options = options;
         this._layers.forEach((layer) => {
-            layer.pm.enable(options);
+            if (layer.pm) {
+                layer.pm.enable(options);
+            }
         });
     },
     disable() {
         this._layers.forEach((layer) => {
-            layer.pm.disable();
+            if (layer.pm) {
+                layer.pm.disable();
+            }
         });
     },
     enabled() {
-        const enabled = this._layers.find(layer => layer.pm.enabled());
+        const enabled = this._layers.find(layer => layer.pm && layer.pm.enabled());
         return !!enabled;
     },
     dragging() {
-        const dragging = this._layers.find(layer => layer.pm.dragging());
+        const dragging = this._layers.find(layer => layer.pm && layer.pm.dragging());
         return !!dragging;
     },
     getOptions() {

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -64,11 +64,13 @@ L.PM.Edit.Line = L.PM.Edit.extend({
         }
 
         // prevent disabling if polygon is being dragged
-        if(poly.pm._dragging) {
+        if(poly.pm && poly.pm._dragging) {
             return false;
         }
-        poly.pm._enabled = false;
-        poly.pm._markerGroup.clearLayers();
+        if (poly.pm) {
+            poly.pm._enabled = false;
+            poly.pm._markerGroup.clearLayers();
+        }
 
         // clean up draggable
         poly.off('mousedown');

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -15,7 +15,7 @@ L.PM.Map = L.Class.extend({
     },
     removeLayer(e) {
         const layer = e.target;
-        if(!layer._layers && !layer.pm.dragging()) {
+        if(!layer._layers && (layer.pm && !layer.pm.dragging())) {
             e.target.remove();
         }
     },
@@ -48,7 +48,9 @@ L.PM.Map = L.Class.extend({
             this._globalEditMode = false;
 
             layers.forEach((layer) => {
-                layer.pm.disable();
+                if (layer.pm) {
+                    layer.pm.disable();
+                }
             });
         } else {
             // enable
@@ -56,7 +58,9 @@ L.PM.Map = L.Class.extend({
             this._globalEditMode = true;
 
             layers.forEach((layer) => {
-                layer.pm.enable(options);
+                if (layer.pm) {
+                    layer.pm.enable(options);
+                }
             });
         }
     },

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -11,7 +11,9 @@ L.Control.PMButton = L.Control.extend({
     onAdd(map) {
         this._map = map;
 
-        this._container = this._map.pm.Toolbar.container;
+        if (this._map.pm) {
+            this._container = this._map.pm.Toolbar.container;
+        }
         this.buttonsDomNode = this._makeButton(this._button);
         this._container.appendChild(this.buttonsDomNode);
 
@@ -85,7 +87,7 @@ L.Control.PMButton = L.Control.extend({
         // before the actual click, trigger a click on currently toggled buttons to
         // untoggle them and their functionality
         L.DomEvent.addListener(newButton, 'click', () => {
-            if(this._button.disableOtherButtons) {
+            if(this._button.disableOtherButtons && this._map.pm) {
                 this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
             }
         });

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -67,7 +67,9 @@ L.PM.Toolbar = L.Class.extend({
 
             },
             afterClick: () => {
-                this.map.pm.toggleRemoval(this.buttons.deleteLayer.toggled());
+                if (this.map.pm) {
+                    this.map.pm.toggleRemoval(this.buttons.deleteLayer.toggled());
+                }
             },
             doToggle: true,
             toggleStatus: false,
@@ -80,8 +82,10 @@ L.PM.Toolbar = L.Class.extend({
 
             },
             afterClick: () => {
-                // toggle drawing mode
-                this.map.pm.Draw.Poly.toggle();
+                if (this.map.pm) {
+                    // toggle drawing mode
+                    this.map.pm.Draw.Poly.toggle();
+                }
             },
             doToggle: true,
             toggleStatus: false,
@@ -94,8 +98,10 @@ L.PM.Toolbar = L.Class.extend({
 
             },
             afterClick: () => {
-                // toggle drawing mode
-                this.map.pm.Draw.Line.toggle();
+                if (this.map.pm) {
+                    // toggle drawing mode
+                    this.map.pm.Draw.Line.toggle();
+                }
             },
             doToggle: true,
             toggleStatus: false,
@@ -107,10 +113,12 @@ L.PM.Toolbar = L.Class.extend({
             onClick: () => {
             },
             afterClick: () => {
-                this.map.pm.toggleGlobalEditMode({
-                    snappable: true,
-                    draggable: true,
-                });
+                if (this.map.pm) {
+                    this.map.pm.toggleGlobalEditMode({
+                        snappable: true,
+                        draggable: true,
+                    });
+                }
             },
             doToggle: true,
             toggleStatus: false,


### PR DESCRIPTION
Was issues with other Leaflet plugins, where leaflet.pm interfered, might be a better more isolated solution but this was a quick fix to make sure no JS errors was thrown.