### PR TITLE
More polyfills for IE

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2,11 +2,11 @@
 
 const map2 = L.map('example2').setView([51.505, -0.09], 13);
 
-map2.on('pm:create', (e) => {
+map2.on('pm:create', function(e) {
     // alert('pm:create event fired. See console for details');
     console.log(e);
 });
-map2.on('pm:remove', (e) => {
+map2.on('pm:remove', function(e) {
     alert('pm:remove event fired. See console for details');
     console.log(e);
 });
@@ -149,27 +149,27 @@ const markerStyle = {
 };
 
 const options = {
-    markerStyle,
+    markerStyle: markerStyle,
 };
 
 map3.pm.enableDraw('Marker', options);
 
 
-geoJsonLayer.addEventListener('click', () => {
+geoJsonLayer.addEventListener('click', function(e) {
     geoJsonLayer.pm.toggleEdit();
 });
 
-geoJsonLayer.on('pm:edit', (e) => {
+geoJsonLayer.on('pm:edit', function(e) {
     console.log(e);
 });
 
-geoJsonLayer.on('pm:dragstart', (e) => {
+geoJsonLayer.on('pm:dragstart', function(e) {
     console.log(e);
 });
-// geoJsonLayer.on('pm:drag', (e) => {
+// geoJsonLayer.on('pm:drag', function(e) {
 //     console.log(e);
 // });
-geoJsonLayer.on('pm:dragend', (e) => {
+geoJsonLayer.on('pm:dragend', function(e) {
     console.log(e);
 });
 
@@ -259,11 +259,11 @@ layerGroup.pm.toggleEdit({
     snapDistance: 30,
 });
 
-layerGroup.on('pm:snap', (e) => {
+layerGroup.on('pm:snap', function(e) {
     console.log('snap');
     console.log(e);
 });
-layerGroup.on('pm:unsnap', (e) => {
+layerGroup.on('pm:unsnap', function(e) {
     console.log('unsnap');
     console.log(e);
 });
@@ -283,19 +283,19 @@ layerGroup.addLayer(layerGroupItem3);
 // layerGroup.addLayer(layerGroupItem4);
 // layerGroup.addLayer(layerGroupItem5);
 
-layerGroup.on('pm:dragstart', (e) => {
+layerGroup.on('pm:dragstart', function(e) {
     console.log(e);
 });
-layerGroup.on('pm:drag', (e) => {
+layerGroup.on('pm:drag', function(e) {
     console.log(e);
 });
-layerGroup.on('pm:dragend', (e) => {
+layerGroup.on('pm:dragend', function(e) {
     console.log(e);
 });
-layerGroup.on('pm:markerdragstart', (e) => {
+layerGroup.on('pm:markerdragstart', function(e) {
     console.log(e);
 });
-layerGroup.on('pm:markerdragend', (e) => {
+layerGroup.on('pm:markerdragend', function(e) {
     console.log(e);
 });
 

--- a/src/js/polyfills.js
+++ b/src/js/polyfills.js
@@ -19,3 +19,45 @@ Array.prototype.find = Array.prototype.find || function(callback) {
     }
   }
 };
+
+// Polyfill for Object.assign()
+// https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+if (typeof Object.assign != 'function') {
+  Object.assign = function(target) {
+    'use strict';
+    if (target == null) {
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    target = Object(target);
+    for (var index = 1; index < arguments.length; index++) {
+      var source = arguments[index];
+      if (source != null) {
+        for (var key in source) {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key];
+          }
+        }
+      }
+    }
+    return target;
+  };
+}
+
+// Polyfill for Element.remove()
+// https://developer.mozilla.org/de/docs/Web/API/ChildNode/remove#Polyfill
+(function (arr) {
+  arr.forEach(function (item) {
+    if (item.hasOwnProperty('remove')) {
+      return;
+    }
+    Object.defineProperty(item, 'remove', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: function remove() {
+        this.parentNode.removeChild(this);
+      }
+    });
+  });
+})([Element.prototype, CharacterData.prototype, DocumentType.prototype]);


### PR DESCRIPTION
Had some time to spare with IE11+ and found some more ES6 hickups (sorry for missing them the first time).

* More polyfills for IE:
  - Object.assign() is needed for snapping
  - Element.remove() is needed when removing control buttons
* demo.js dumbed down for IE11:
  - IE doesn't understand thoose fancy lambdy style expressions
  - object literals always need a key