### PR TITLE
Don't use cheap-eval-source-map in main build

### DIFF
--- a/webpack.build.js
+++ b/webpack.build.js
@@ -1,11 +1,12 @@
 /* eslint import/no-extraneous-dependencies: 0 */
+var webpack = require('webpack');
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const path = require('path');
 
 module.exports = {
     watch: false,
-    devtool: 'cheap-eval-source-map',
+    devtool: 'cheap-source-map',
     entry: ['./src/js/L.PM.js'],
     output: {
         filename: 'leaflet.pm.min.js',
@@ -38,5 +39,6 @@ module.exports = {
     },
     plugins: [
         new ExtractTextPlugin('leaflet.pm.css'),
+        new webpack.optimize.UglifyJsPlugin(),
     ],
 };

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -1,6 +1,5 @@
 /* eslint import/no-extraneous-dependencies: 0 */
-var webpack = require('webpack');
-
+const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const path = require('path');
 


### PR DESCRIPTION
This PM changes the build source map and minimise the source. `cheap-eval-source-map` is not production safe and should therefore only be in the development build. See https://webpack.js.org/configuration/devtool/. 