### PR TITLE
Map drag fix

### DIFF
--- a/src/js/Mixins/Drag.js
+++ b/src/js/Mixins/Drag.js
@@ -96,8 +96,6 @@ const DragMixin = {
 
         this._layer.on('mouseup', this._dragMixinOnMouseUp, this);
 
-        console.log(this)
-
         // listen to mousemove on map (instead of polygon),
         // otherwise fast mouse movements stop the drag
         this._layer._map.on('mousemove', this._dragMixinOnMouseMove, this);

--- a/src/js/Mixins/Drag.js
+++ b/src/js/Mixins/Drag.js
@@ -23,7 +23,7 @@ const DragMixin = {
             this._layer._map.dragging.enable();
         }
 
-        // if event fired, it's safe to cache the map draggable state on the next mouse down
+        // if mouseup event fired, it's safe to cache the map draggable state on the next mouse down
         this._safeToCacheDragState = true
 
         // clear up mousemove event

--- a/src/js/Mixins/Drag.js
+++ b/src/js/Mixins/Drag.js
@@ -7,6 +7,12 @@ const DragMixin = {
         const el = this._layer._path;
         L.DomUtil.addClass(el, 'leaflet-pm-draggable');
 
+        this._originalMapDragState = this._layer._map.dragging._enabled;
+
+        // can we reliably save the map's draggable state?
+        // (if the mouse up event happens outside the container, then the map can become undraggable)
+        this._safeToCacheDragState = true;
+
         this._layer.on('mousedown', this._dragMixinOnMouseDown, this);
     },
     _dragMixinOnMouseUp() {
@@ -16,6 +22,9 @@ const DragMixin = {
         if(this._originalMapDragState) {
             this._layer._map.dragging.enable();
         }
+
+        // if event fired, it's safe to cache the map draggable state on the next mouse down
+        this._safeToCacheDragState = true
 
         // clear up mousemove event
         this._layer._map.off('mousemove', this._dragMixinOnMouseMove, this);
@@ -75,12 +84,19 @@ const DragMixin = {
     },
     _dragMixinOnMouseDown(e) {
         // save current map dragging state
-        this._originalMapDragState = this._layer._map.dragging._enabled;
+        if(this._safeToCacheDragState){
+            this._originalMapDragState = this._layer._map.dragging._enabled;
+
+            // don't cache the state again until another mouse up is registered
+            this._safeToCacheDragState = false           
+        }
 
         // save for delta calculation
         this._tempDragCoord = e.latlng;
 
         this._layer.on('mouseup', this._dragMixinOnMouseUp, this);
+
+        console.log(this)
 
         // listen to mousemove on map (instead of polygon),
         // otherwise fast mouse movements stop the drag


### PR DESCRIPTION
Closes #202 

If you drag a Polygon such that the cursor goes off the map, the **mouseup** event that resets the map's draggable state never fires. This means that when we click back into the map and the **mousedown** event binding saves the map's current draggable state, it is always **false**.

The basic idea of this PR is that we first record the map's draggable state upon draggable layer initialization, and then use an additional flag to see if it's "safe" to cache the map's draggable state during all subsequent **mousedown** events.

It's always safe upon first initializing the draggable layer, as no **mousedown** event could have possibly occurred.

After that, it only becomes safe upon  capturing a **mouseup** event within the map container. This way, if you click outside then click back in, it doesn't save the new (always **false**) draggable state, instead defaulting to the state detected during the initial **mousedown** event that started the Polygon drag!