### PR TITLE
Add mouseup event to line/polygon markers

### DIFF
--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -142,6 +142,7 @@ Edit.Line = Edit.extend({
         marker.on('move', this._onMarkerDrag, this);
         marker.on('dragend', this._onMarkerDragEnd, this);
         marker.on('contextmenu', this._removeMarker, this);
+        marker.on('mouseup', this._onMouseUp, this);
 
         this._markerGroup.addLayer(marker);
 
@@ -401,7 +402,11 @@ Edit.Line = Edit.extend({
             markerEvent: e,
         });
     },
-
+    _onMouseUp(e) {
+        this._layer.fire('pm:markermouseup', {
+            markerEvent: e,
+        });
+    },
     _fireEdit() {
         // fire edit event
         this._layer.edited = true;


### PR DESCRIPTION
I am looking to detect a vertex click or change for a line/polygon.  'mouseup' event will handle both.  Thoughts?