### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ Download [`leaflet.pm.css`](https://unpkg.com/leaflet.pm@latest/dist/leaflet.pm.
 #### Include via CDN
 CSS
 ``` html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.pm@latest/dist/leaflet.pm.min.css">
+<!-- or -->
 <link rel="stylesheet" href="https://unpkg.com/leaflet.pm@latest/dist/leaflet.pm.css" />
 ```
 
 JS
 ``` html
+<script src="https://cdn.jsdelivr.net/npm/leaflet.pm@latest/dist/leaflet.pm.min.js"></script>
+<!-- or -->
 <script src="https://unpkg.com/leaflet.pm@latest/dist/leaflet.pm.min.js"></script>
 ```
 


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/leaflet.pm) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability. We also have detailed usage stats for project maintainers.