### PR TITLE
Cut events update

### DIFF
--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -31,11 +31,11 @@ Draw.Cut = Draw.Poly.extend({
                 }
             });
 
-        // the resulting layers after the cut
-        const resultingLayers = [];
 
         // loop through all layers that intersect with the drawn (cutting) layer
         layers.forEach((l) => {
+            // the resulting layers after the cut
+            const resultingLayers = [];
             // find layer difference
             const diff = difference(l.toGeoJSON(), layer.toGeoJSON());
 


### PR DESCRIPTION
when the cut event is fired it includes resulting layers from all the previous cut events, so if you cut several polygons each successive cut event accumulates previous resulting layers 

this update only includes resulting layers for the current cutted layer