### PR TITLE
fix(snapping): fix bug when the map contains a multi-geometry features (MultiPolygon / MultiLine)

### DIFF
--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -195,9 +195,6 @@ const SnapMixin = {
                 else {
                     layers.push(layer);
                 }
-
-                map.off('pm:remove', this._handleSnapLayerRemoval, this);
-                map.on('pm:remove', this._handleSnapLayerRemoval, this);
             }
         });
 
@@ -224,6 +221,8 @@ const SnapMixin = {
             this._snapList = layers;
         }
 
+        map.off('pm:remove', this._handleSnapLayerRemoval, this);
+        map.on('pm:remove', this._handleSnapLayerRemoval, this);
     },
     _calcClosestLayer(latlng, layers) {
         // the closest polygon to our dragged marker latlng

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -198,16 +198,16 @@ const SnapMixin = {
 
                 map.off('pm:remove', this._handleSnapLayerRemoval, this);
                 map.on('pm:remove', this._handleSnapLayerRemoval, this);
-
-                // this is for debugging
-                const debugLine = L.polyline([], { color: 'red', pmIgnore: true });
-                debugIndicatorLines.push(debugLine);
-
-                // uncomment 👇 this line to show helper lines for debugging
-                // debugLine.addTo(map);
             }
         });
 
+        // this is for debugging
+        this.debugIndicatorLines = layers.map(() =>
+            L.polyline([], { color: 'red', pmIgnore: true }),
+        );
+
+        // uncomment 👇 this line to show helper lines for debugging
+        // this.debugIndicatorLines.forEach(debugLine => debugLine.addTo(map));
         // ...except myself
         layers = layers.filter(layer => this._layer !== layer);
 
@@ -224,7 +224,6 @@ const SnapMixin = {
             this._snapList = layers;
         }
 
-        this.debugIndicatorLines = debugIndicatorLines;
     },
     _calcClosestLayer(latlng, layers) {
         // the closest polygon to our dragged marker latlng

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -183,8 +183,16 @@ const SnapMixin = {
                 if (layer instanceof L.Polygon && layer._latlngs[0][0] instanceof Array) {
                     layer._latlngs.forEach(ring =>
                         layers.push(new L.Polygon(ring))
-                } else {
                     );
+                }
+                // split MultiLine layers into multiple single Polyline layers
+                else if (layer instanceof L.Polyline && layer._latlngs[0] instanceof Array) {
+                    layer._latlngs.forEach(segment =>
+                        layers.push(new L.Polyline(segment))
+                    );
+                }
+                // MultiPoint layers aren't causing any troubles, add all remaining layers as they are
+                else {
                     layers.push(layer);
                 }
 

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -179,7 +179,14 @@ const SnapMixin = {
         // temporary markers of polygon-edits
         map.eachLayer((layer) => {
             if (layer instanceof L.Polyline || layer instanceof L.Marker || layer instanceof L.CircleMarker) {
-                layers.push(layer);
+                // split MultiPolygon layers into multiple single Polygon layers
+                if (layer instanceof L.Polygon && layer._latlngs[0][0] instanceof Array) {
+                    layer._latlngs.forEach(ring =>
+                        layers.push(new L.Polygon(ring))
+                } else {
+                    );
+                    layers.push(layer);
+                }
 
                 map.off('pm:remove', this._handleSnapLayerRemoval, this);
                 map.on('pm:remove', this._handleSnapLayerRemoval, this);


### PR DESCRIPTION
MultiPolygon layers trigger a bug in the snapping algorithm. This PR fixes this by breaking the MultiPolygon layers up before adding to the `_snapList`.

Fixes #257. More details explained in this comment: https://github.com/codeofsumit/leaflet.pm/issues/257#issuecomment-386079468