### PR TITLE
Increase GeoJSON precision

### DIFF
--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -24,7 +24,7 @@ Draw.Cut = Draw.Poly.extend({
             // only layers with intersections
             .filter((l) => {
                 try {
-                    return !!intersect(layer.toGeoJSON(), l.toGeoJSON());
+                    return !!intersect(layer.toGeoJSON(15), l.toGeoJSON(15));
                 } catch (e) {
                     console.error('You cant cut polygons with self-intersections');
                     return false;
@@ -37,7 +37,7 @@ Draw.Cut = Draw.Poly.extend({
             // the resulting layers after the cut
             const resultingLayers = [];
             // find layer difference
-            const diff = difference(l.toGeoJSON(), layer.toGeoJSON());
+            const diff = difference(l.toGeoJSON(15), layer.toGeoJSON(15));
 
             // add new layer to map
             const newL = L.geoJSON(diff, l.options).addTo(this._map);

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -134,7 +134,7 @@ Draw.Line = Draw.extend({
     },
     hasSelfIntersection() {
         // check for self intersection of the layer and return true/false
-        const selfIntersection = kinks(this._layer.toGeoJSON());
+        const selfIntersection = kinks(this._layer.toGeoJSON(15));
         return selfIntersection.features.length > 0;
     },
     _syncHintLine() {
@@ -177,7 +177,7 @@ Draw.Line = Draw.extend({
         clone.addLatLng(this._hintMarker.getLatLng());
 
         // check the self intersection
-        const selfIntersection = kinks(clone.toGeoJSON());
+        const selfIntersection = kinks(clone.toGeoJSON(15));
         this._doesSelfIntersect = selfIntersection.features.length > 0;
 
         // change the style based on self intersection

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -113,7 +113,7 @@ Edit.Line = Edit.extend({
 
     hasSelfIntersection() {
         // check for self intersection of the layer and return true/false
-        const selfIntersection = kinks(this._layer.toGeoJSON());
+        const selfIntersection = kinks(this._layer.toGeoJSON(15));
         return selfIntersection.features.length > 0;
     },
 
@@ -151,7 +151,7 @@ Edit.Line = Edit.extend({
 
             // fire intersect event
             this._layer.fire('pm:intersect', {
-                intersection: kinks(this._layer.toGeoJSON()),
+                intersection: kinks(this._layer.toGeoJSON(15)),
             });
         } else {
             // if not, reset the style to the default color

--- a/src/js/Mixins/Overlap.js
+++ b/src/js/Mixins/Overlap.js
@@ -34,7 +34,7 @@ var OverlapMixin = {
         const mainPoly = this._poly;
         const layers = this._layerGroup.getLayers();
         let changed = false;
-        let resultingGeoJson = this._poly.toGeoJSON();
+        let resultingGeoJson = this._poly.toGeoJSON(15);
 
         layers
         .filter(layer => !Object.is(layer, mainPoly))
@@ -44,13 +44,13 @@ var OverlapMixin = {
             // this needs to be in a try catch block because turf isn't reliable
             // it throws self-intersection errors even if there are none
             try {
-                intersect = turf.intersect(resultingGeoJson, layer.toGeoJSON());
+                intersect = turf.intersect(resultingGeoJson, layer.toGeoJSON(15));
             } catch(e) {
                 console.warn('Turf Error.');
             }
 
             if(intersect) {
-                resultingGeoJson = turf.difference(resultingGeoJson, layer.toGeoJSON());
+                resultingGeoJson = turf.difference(resultingGeoJson, layer.toGeoJSON(15));
 
                 // if the resulting polygon is a MultiPolygon, don't handle it.
                 if(resultingGeoJson.geometry.type !== 'MultiPolygon') {


### PR DESCRIPTION
I've increased precision when working with GeoJSON due to false-positive polygon self-intersection in scenarios with two close points.

Dataset with false-positive self-intersection:
[false_self_intersection.txt](https://github.com/codeofsumit/leaflet.pm/files/2123561/false_self_intersection.txt)
