### PR TITLE
Snap middle of segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ var options = {
     snappable: true,
     snapDistance: 20,
 
-    // allow snapping with the middle of segments
+    // allow snapping to the middle of segments
     snapMiddle: false,
 
     // self intersection

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ map.pm.enableDraw('Poly', { finishOn: 'dblclick' });
 map.pm.disableDraw('Poly');
 ```
 
-All available options are specified in the Drawing Mode Section below
+All available options are specified in the Drawing Mode Section below.
 
 ##### Drawing Mode
 
@@ -129,6 +129,9 @@ var options = {
     // snapping
     snappable: true,
     snapDistance: 20,
+
+    // allow snapping with the middle of segments
+    snapMiddle: false,
 
     // self intersection
     allowSelfIntersection: true,

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -1,6 +1,7 @@
 import kinks from '@turf/kinks';
 import get from 'lodash/get';
 import Edit from './L.PM.Edit';
+import Utils from '../L.PM.Utils';
 
 // Shit's getting complicated in here with Multipolygon Support. So here's a quick note about it:
 // Multipolygons with holes means lots of nested, multidimensional arrays.
@@ -231,7 +232,7 @@ Edit.Line = Edit.extend({
             return false;
         }
 
-        const latlng = this._calcMiddleLatLng(leftM.getLatLng(), rightM.getLatLng());
+        const latlng = Utils.calcMiddleLatLng(this._map, leftM.getLatLng(), rightM.getLatLng());
 
         const middleMarker = this._createMarker(latlng);
         const middleIcon = L.divIcon({ className: 'marker-icon marker-icon-middle' });
@@ -498,12 +499,12 @@ Edit.Line = Edit.extend({
         const nextMarkerLatLng = markerArr[nextMarkerIndex].getLatLng();
 
         if (marker._middleMarkerNext) {
-            const middleMarkerNextLatLng = this._calcMiddleLatLng(markerLatLng, nextMarkerLatLng);
+            const middleMarkerNextLatLng = Utils.calcMiddleLatLng(this._map, markerLatLng, nextMarkerLatLng);
             marker._middleMarkerNext.setLatLng(middleMarkerNextLatLng);
         }
 
         if (marker._middleMarkerPrev) {
-            const middleMarkerPrevLatLng = this._calcMiddleLatLng(markerLatLng, prevMarkerLatLng);
+            const middleMarkerPrevLatLng = Utils.calcMiddleLatLng(this._map, markerLatLng, prevMarkerLatLng);
             marker._middleMarkerPrev.setLatLng(middleMarkerPrevLatLng);
         }
 
@@ -560,18 +561,5 @@ Edit.Line = Edit.extend({
         // fire edit event
         this._layerEdited = true;
         this._layer.fire('pm:edit');
-    },
-
-    _calcMiddleLatLng(latlng1, latlng2) {
-        // calculate the middle coordinates between two markers
-        // TODO: put this into a utils.js or something
-
-        const map = this._map;
-        const p1 = map.project(latlng1);
-        const p2 = map.project(latlng2);
-
-        const latlng = map.unproject(p1._add(p2)._divideBy(2));
-
-        return latlng;
     },
 });

--- a/src/js/L.PM.Utils.js
+++ b/src/js/L.PM.Utils.js
@@ -1,0 +1,12 @@
+const Utils = {
+    calcMiddleLatLng(map, latlng1, latlng2) {
+        // calculate the middle coordinates between two markers
+
+        const p1 = map.project(latlng1);
+        const p2 = map.project(latlng2);
+
+        return map.unproject(p1._add(p2)._divideBy(2));
+    },
+};
+
+export default Utils;

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -1,7 +1,8 @@
+import Utils from '../L.PM.Utils';
+
 const SnapMixin = {
     _initSnappableMarkers() {
         this.options.snapDistance = this.options.snapDistance || 30;
-        this.options.snapMiddle = this.options.snapMiddle;
 
         this._assignEvents(this._markers);
 
@@ -155,13 +156,16 @@ const SnapMixin = {
         // distance between closestVertexLatLng and C
         let shortestDistance = distanceAC < distanceBC ? distanceAC : distanceBC;
 
-        // snap to middle of segment if enabled
+        // snap to middle (M) of segment if option is enabled
         if (this.options.snapMiddle) {
-            const M = this._middleLatLng(map, A, B);
+            const M = Utils.calcMiddleLatLng(map, A, B);
             const distanceMC = this._getDistance(map, M, C);
-            const middleIsNearest = (distanceMC < distanceAC && distanceMC < distanceBC);
-            closestVertexLatLng = middleIsNearest ? M : closestVertexLatLng;
-            shortestDistance = middleIsNearest ? distanceMC : shortestDistance;
+
+            if (distanceMC < distanceAC && distanceMC < distanceBC) {
+                // M is the nearest vertex
+                closestVertexLatLng = M;
+                shortestDistance = distanceMC;
+            }
         }
 
         // the distance that needs to be undercut to trigger priority
@@ -170,7 +174,7 @@ const SnapMixin = {
         // the latlng we ultemately want to snap to
         let snapLatlng;
 
-        // if C is closer to the closestVertexLatLng (A or B) than the snapDistance,
+        // if C is closer to the closestVertexLatLng (A, B or M) than the snapDistance,
         // the closestVertexLatLng has priority over C as the snapping point.
         if (shortestDistance < priorityDistance) {
             snapLatlng = closestVertexLatLng;
@@ -342,12 +346,6 @@ const SnapMixin = {
     },
     _getDistance(map, latlngA, latlngB) {
         return map.latLngToLayerPoint(latlngA).distanceTo(map.latLngToLayerPoint(latlngB));
-    },
-    _middleLatLng(map, latlngA, latlngB) {
-        const p1 = map.project(latlngA);
-        const p2 = map.project(latlngB);
-
-        return map.unproject(p1._add(p2)._divideBy(2));
     },
 };
 


### PR DESCRIPTION
Hi,

This PR add an option, disabled by default, allowing snap middle of segments.

Here is a quick demo : 

![leafletpm snap middle](https://user-images.githubusercontent.com/12164749/42508732-dcbeea58-8449-11e8-9fe6-2327d12cf738.gif)

Usage : enable with `snapMiddle: true` in your options. (See edited README)