### PR TITLE
[bugfix] Fix snapping for single point lines/poly

### DIFF
--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -299,7 +299,8 @@ const SnapMixin = {
                     nextIndex = index + 1 === coords.length ? undefined : index + 1;
                 }
 
-                const B = coords[nextIndex];
+                // if that's a line or poly where coord[begin] = coord[end], then B = A
+                const B = (index === 0 && nextIndex === undefined) ? A : coords[nextIndex];
 
                 if (B) {
                     // calc the distance between P and AB-segment


### PR DESCRIPTION
Hi,

This PR aims to fix a bug detected in snapping. After drawing a "single point line" (a line where begin = end), console errors occurs.

![leafletpm bug snapping](https://user-images.githubusercontent.com/12164749/43312463-a5a709e6-918d-11e8-9e06-9c06c853efdc.gif)