### PR TITLE
Fix Actions Positioning

### DIFF
--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -12,9 +12,17 @@ describe('Testing the Toolbar', () => {
             });
         });
 
+        cy.toolbarButton('polygon').click();
+
+        cy.get('.leaflet-pm-actions-container')
+            .should('have.css', 'right')
+            .and('match', /31px/);
+
         cy.get('.leaflet-pm-toolbar')
             .parent('.leaflet-top.leaflet-right')
             .should('exist');
+
+        cy.get('.button-container.active .action-cancel').click();
 
         cy.window().then(({ map }) => {
             map.pm.addControls({

--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -87,6 +87,14 @@
     white-space: nowrap;
 }
 
+.leaflet-right
+    .leaflet-pm-toolbar
+    .button-container
+    .leaflet-pm-actions-container {
+    right: 31px;
+    left: auto;
+}
+
 .button-container.active .leaflet-pm-actions-container {
     display: block;
 }


### PR DESCRIPTION
When positioning the toolbar on the right, the actions are now displayed properly on the left side of the toolbar. Fixes #371 