### PR TITLE
Change pm:remove event trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Leaflet Geometry Management
 
-
 [![npm version](https://badge.fury.io/js/leaflet.pm.svg)](https://badge.fury.io/js/leaflet.pm)
 ![](https://travis-ci.com/codeofsumit/leaflet.pm.svg?branch=develop)
 [![star this repo](http://githubbadges.com/star.svg?user=codeofsumit&repo=leaflet.pm&style=default)](https://github.com/codeofsumit/leaflet.pm)
@@ -357,7 +356,10 @@ polygonLayer.pm.hasSelfIntersection(); // true/false
 // toggle global removal mode
 map.pm.toggleGlobalRemovalMode();
 
-// listen to removal of layers that are NOT ignored and NOT helpers by leaflet.pm
+// listen to removal of layers
+map.on('layerremove', function(e) {});
+
+// listen to removal of layers by leaflet.pm
 map.on('pm:remove', function(e) {});
 ```
 

--- a/cypress/integration/polygon.spec.js
+++ b/cypress/integration/polygon.spec.js
@@ -93,7 +93,7 @@ describe('Draw & Edit Poly', () => {
         });
     });
 
-    it.only('events to be called', () => {
+    it('events to be called', () => {
         cy.window().then(({ map }) => {
             // test pm:create event
             Cypress.$(map).on('pm:create', ({ originalEvent: event }) => {

--- a/cypress/integration/polygon.spec.js
+++ b/cypress/integration/polygon.spec.js
@@ -93,7 +93,7 @@ describe('Draw & Edit Poly', () => {
         });
     });
 
-    it('pm:create to be called', () => {
+    it.only('events to be called', () => {
         cy.window().then(({ map }) => {
             // test pm:create event
             Cypress.$(map).on('pm:create', ({ originalEvent: event }) => {
@@ -102,6 +102,13 @@ describe('Draw & Edit Poly', () => {
 
                 const markers = poly.pm._markers[0];
                 expect(markers).to.have.length(4);
+            });
+
+            Cypress.$(map).on('pm:remove', ({ originalEvent: event }) => {
+                const layer = event.target;
+
+                /* eslint no-unused-expressions: 0 */
+                expect(layer.map).to.be.undefined;
             });
         });
 
@@ -118,6 +125,10 @@ describe('Draw & Edit Poly', () => {
             .click(150, 50)
             .click(150, 150)
             .click(90, 250);
+
+        cy.toolbarButton('delete').click();
+
+        cy.get(mapSelector).click(110, 150);
     });
 
     it('draws and edits a polygon', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5306,9 +5306,9 @@
       }
     },
     "leaflet": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.4.tgz",
-      "integrity": "sha512-FYL1LGFdj6v+2Ifpw+AcFIuIOqjNggfoLUwuwQv6+3sS21Za7Wvapq+LhbSE4NDXrEj6eYnW3y7LsaBICpyXtw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.4.0.tgz",
+      "integrity": "sha512-x9j9tGY1+PDLN9pcWTx9/y6C5nezoTMB8BLK5jTakx+H7bPlnbCHfi9Hjg+Qt36sgDz/cb9lrSpNQXmk45Tvhw==",
       "dev": true
     },
     "levn": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-import": "^2.9.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^0.11.1",
-    "leaflet": "^1.3.4",
+    "leaflet": "^1.4.0",
     "style-loader": "^0.19.0",
     "uglifyjs-webpack-plugin": "^1.3.0",
     "url-loader": "^0.6.2",

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -51,7 +51,11 @@ Edit.Line = Edit.extend({
         this._layer.on('remove', this._onLayerRemove, this);
 
         if (!this.options.allowSelfIntersection) {
-            this._layer.on('pm:vertexremoved', this._handleSelfIntersectionOnVertexRemoval, this);
+            this._layer.on(
+                'pm:vertexremoved',
+                this._handleSelfIntersectionOnVertexRemoval,
+                this,
+            );
         }
 
         if (this.options.draggable) {
@@ -89,10 +93,13 @@ Edit.Line = Edit.extend({
         poly.off('mouseup');
 
         // remove onRemove listener
-        this._layer.off('remove', this._onLayerRemove);
+        this._layer.off('remove', this._onLayerRemove, this);
 
         if (!this.options.allowSelfIntersection) {
-            this._layer.off('pm:vertexremoved', this._handleSelfIntersectionOnVertexRemoval);
+            this._layer.off(
+                'pm:vertexremoved',
+                this._handleSelfIntersectionOnVertexRemoval,
+            );
         }
 
         // remove draggable class
@@ -133,7 +140,9 @@ Edit.Line = Edit.extend({
     },
 
     _handleLayerStyle(flash) {
-        const el = this._layer._path ? this._layer._path : this._layer._renderer._container;
+        const el = this._layer._path
+            ? this._layer._path
+            : this._layer._renderer._container;
 
         if (this.hasSelfIntersection()) {
             if (L.DomUtil.hasClass(el, 'leaflet-pm-invalid')) {
@@ -187,7 +196,9 @@ Edit.Line = Edit.extend({
             // create small markers in the middle of the regular markers
             coordsArr.map((v, k) => {
                 // find the next index fist
-                const nextIndex = this.isPolygon() ? (k + 1) % coordsArr.length : k + 1;
+                const nextIndex = this.isPolygon()
+                    ? (k + 1) % coordsArr.length
+                    : k + 1;
                 // create the marker
                 return this._createMiddleMarker(ringArr[k], ringArr[nextIndex]);
             });
@@ -232,10 +243,16 @@ Edit.Line = Edit.extend({
             return false;
         }
 
-        const latlng = Utils.calcMiddleLatLng(this._map, leftM.getLatLng(), rightM.getLatLng());
+        const latlng = Utils.calcMiddleLatLng(
+            this._map,
+            leftM.getLatLng(),
+            rightM.getLatLng(),
+        );
 
         const middleMarker = this._createMarker(latlng);
-        const middleIcon = L.divIcon({ className: 'marker-icon marker-icon-middle' });
+        const middleIcon = L.divIcon({
+            className: 'marker-icon marker-icon-middle',
+        });
         middleMarker.setIcon(middleIcon);
 
         // save reference to this middle markers on the neighboor regular markers
@@ -281,13 +298,20 @@ Edit.Line = Edit.extend({
         const coords = this._layer._latlngs;
 
         // the index path to the marker inside the multidimensional marker array
-        const { indexPath, index, parentPath } = this.findDeepMarkerIndex(this._markers, leftM);
+        const { indexPath, index, parentPath } = this.findDeepMarkerIndex(
+            this._markers,
+            leftM,
+        );
 
         // define the coordsRing that is edited
-        const coordsRing = indexPath.length > 1 ? get(coords, parentPath) : coords;
+        const coordsRing =
+            indexPath.length > 1 ? get(coords, parentPath) : coords;
 
         // define the markers array that is edited
-        const markerArr = indexPath.length > 1 ? get(this._markers, parentPath) : this._markers;
+        const markerArr =
+            indexPath.length > 1
+                ? get(this._markers, parentPath)
+                : this._markers;
 
         // add coordinate to coordinate array
         coordsRing.splice(index + 1, 0, latlng);
@@ -333,7 +357,10 @@ Edit.Line = Edit.extend({
         const coords = this._layer.getLatLngs();
 
         // the index path to the marker inside the multidimensional marker array
-        const { indexPath, index, parentPath } = this.findDeepMarkerIndex(this._markers, marker);
+        const { indexPath, index, parentPath } = this.findDeepMarkerIndex(
+            this._markers,
+            marker,
+        );
 
         // only continue if this is NOT a middle marker (those can't be deleted)
         if (!indexPath) {
@@ -341,10 +368,14 @@ Edit.Line = Edit.extend({
         }
 
         // define the coordsRing that is edited
-        const coordsRing = indexPath.length > 1 ? get(coords, parentPath) : coords;
+        const coordsRing =
+            indexPath.length > 1 ? get(coords, parentPath) : coords;
 
         // define the markers array that is edited
-        const markerArr = indexPath.length > 1 ? get(this._markers, parentPath) : this._markers;
+        const markerArr =
+            indexPath.length > 1
+                ? get(this._markers, parentPath)
+                : this._markers;
 
         // remove coordinate
         coordsRing.splice(index, 1);
@@ -390,11 +421,13 @@ Edit.Line = Edit.extend({
         if (this.isPolygon()) {
             // find neighbor marker-indexes
             rightMarkerIndex = (index + 1) % markerArr.length;
-            leftMarkerIndex = (index + (markerArr.length - 1)) % markerArr.length;
+            leftMarkerIndex =
+                (index + (markerArr.length - 1)) % markerArr.length;
         } else {
             // find neighbor marker-indexes
             leftMarkerIndex = index - 1 < 0 ? undefined : index - 1;
-            rightMarkerIndex = index + 1 >= markerArr.length ? undefined : index + 1;
+            rightMarkerIndex =
+                index + 1 >= markerArr.length ? undefined : index + 1;
         }
 
         // don't create middlemarkers if there is only one marker left
@@ -421,7 +454,12 @@ Edit.Line = Edit.extend({
     isEmptyDeep(l) {
         // thanks for the function, Felix Heck
         const flatten = list =>
-            list.filter(x => ![null, '', undefined].includes(x)).reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
+            list
+                .filter(x => ![null, '', undefined].includes(x))
+                .reduce(
+                    (a, b) => a.concat(Array.isArray(b) ? flatten(b) : b),
+                    [],
+                );
 
         return !flatten(l).length;
     },
@@ -461,7 +499,10 @@ Edit.Line = Edit.extend({
         const latlng = marker.getLatLng();
 
         // get indexPath of Marker
-        const { indexPath, index, parentPath } = this.findDeepMarkerIndex(this._markers, marker);
+        const { indexPath, index, parentPath } = this.findDeepMarkerIndex(
+            this._markers,
+            marker,
+        );
 
         // update coord
         const parent = indexPath.length > 1 ? get(coords, parentPath) : coords;
@@ -475,7 +516,10 @@ Edit.Line = Edit.extend({
         // dragged marker
         const marker = e.target;
 
-        const { indexPath, index, parentPath } = this.findDeepMarkerIndex(this._markers, marker);
+        const { indexPath, index, parentPath } = this.findDeepMarkerIndex(
+            this._markers,
+            marker,
+        );
 
         // only continue if this is NOT a middle marker
         if (!indexPath) {
@@ -485,11 +529,15 @@ Edit.Line = Edit.extend({
         this.updatePolygonCoordsFromMarkerDrag(marker);
 
         // the dragged markers neighbors
-        const markerArr = indexPath.length > 1 ? get(this._markers, parentPath) : this._markers;
+        const markerArr =
+            indexPath.length > 1
+                ? get(this._markers, parentPath)
+                : this._markers;
 
         // find the indizes of next and previous markers
         const nextMarkerIndex = (index + 1) % markerArr.length;
-        const prevMarkerIndex = (index + (markerArr.length - 1)) % markerArr.length;
+        const prevMarkerIndex =
+            (index + (markerArr.length - 1)) % markerArr.length;
 
         // update middle markers on the left and right
         // be aware that "next" and "prev" might be interchanged, depending on the geojson array
@@ -500,12 +548,20 @@ Edit.Line = Edit.extend({
         const nextMarkerLatLng = markerArr[nextMarkerIndex].getLatLng();
 
         if (marker._middleMarkerNext) {
-            const middleMarkerNextLatLng = Utils.calcMiddleLatLng(this._map, markerLatLng, nextMarkerLatLng);
+            const middleMarkerNextLatLng = Utils.calcMiddleLatLng(
+                this._map,
+                markerLatLng,
+                nextMarkerLatLng,
+            );
             marker._middleMarkerNext.setLatLng(middleMarkerNextLatLng);
         }
 
         if (marker._middleMarkerPrev) {
-            const middleMarkerPrevLatLng = Utils.calcMiddleLatLng(this._map, markerLatLng, prevMarkerLatLng);
+            const middleMarkerPrevLatLng = Utils.calcMiddleLatLng(
+                this._map,
+                markerLatLng,
+                prevMarkerLatLng,
+            );
             marker._middleMarkerPrev.setLatLng(middleMarkerPrevLatLng);
         }
 


### PR DESCRIPTION
`pm:remove` won't fire on every layerremove now. It will only fire if a layer was removed via leaflet.pm the toolbar. This is an important distiction as some applications remove layers to redraw them while the removal tool of leaflet.pm serves the purpose of actually deleting a layer. The `pm:remove` event should cover that scenario.
For all other instances, leaflets own `layerremove` event will do.