### PR TITLE
Remove Fully Cutted Layer

### DIFF
--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -26,7 +26,7 @@ Draw.Cut = Draw.Poly.extend({
                 try {
                     return !!intersect(layer.toGeoJSON(15), l.toGeoJSON(15));
                 } catch (e) {
-                    console.error('You cant cut polygons with self-intersections');
+                    console.error('You cant cut polygons with self-intersections',);
                     return false;
                 }
             });
@@ -65,13 +65,22 @@ Draw.Cut = Draw.Poly.extend({
             // remove old layer and cutting layer
             l.remove();
             layer.remove();
+
+            if (resultingLayer.getLayers().length === 0) {
+                this._map.pm.removeLayer({ target: resultingLayer });
+            }
         });
     },
-    _finishShape() {
+    _finishShape(e) {
         // if self intersection is not allowed, do not finish the shape!
-        if (!this.options.allowSelfIntersection && this._doesSelfIntersect) {
-            return;
+        if (!this.options.allowSelfIntersection) {
+            this._handleSelfIntersection(e.latlng);
+
+            if (this._doesSelfIntersect) {
+                return;
+            }
         }
+
         const coords = this._layer.getLatLngs();
         const polygonLayer = L.polygon(coords, this.options.pathOptions);
         this._cut(polygonLayer);

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -29,13 +29,14 @@ const Map = L.Class.extend({
     },
     removeLayer(e) {
         const layer = e.target;
-        if (
-            !layer._layers &&
-            !layer._pmTempLayer &&
-            (!layer.pm || !layer.pm.dragging())
-        ) {
+        // only remove layer, if it's handled by leaflet.pm,
+        // not a tempLayer and not currently being dragged
+        const removeable =
+            !layer._pmTempLayer && (!layer.pm || !layer.pm.dragging());
+
+        if (removeable) {
             layer.remove();
-            this.map.fire('pm:remove', e);
+            this.map.fire('pm:remove', { layer });
         }
     },
     toggleGlobalRemovalMode() {


### PR DESCRIPTION
If all vertices of a layer are removed using the cut tool, we remove the layer from the map and trigger `pm:remove` instead of leaving the layer on the map without vertexes.