### PR TITLE
Add I18n Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Check out **[Geoman](https://geoman.io/#pricing)** and consider subscribing to t
 - [Drag Mode](#drag-mode)
 - [Removal Mode](#removal-mode)
 - [Cutting Mode](#cutting-mode)
-- [Style Customization](#customize-style)
+- [Customization](#customize)
 - [Need a feature?](#feature-request) | [Existing Feature Requests](https://github.com/codeofsumit/leaflet.pm/issues?q=is%3Aissue+is%3Aclosed+label%3A%22feature+request%22+sort%3Areactions-%2B1-desc)
 
 ### Installation
@@ -379,7 +379,20 @@ The following events are available on a map instance:
 | :----- | :----- | :-------------------------------- |
 | pm:cut | `e`    | Fired when any layer is being cut |
 
-### Customize Style
+### Customize
+
+##### Customize Language
+
+Change the language of user-facing copy in leaflet.pm
+
+```js
+map.pm.setLang('de');
+```
+
+Currently available languages are `de` and `en`.
+To add translations to the plugin, you can add [a translation file](https://github.com/codeofsumit/leaflet.pm/src/assets/translations) via Pull Request.
+
+##### Customize Style
 
 In order to change the style of the lines during draw, pass these options to the
 `enableDraw()` function.

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ map.pm.setLang('de');
 ```
 
 Currently available languages are `de` and `en`.
-To add translations to the plugin, you can add [a translation file](https://github.com/codeofsumit/leaflet.pm/src/assets/translations) via Pull Request.
+To add translations to the plugin, you can add [a translation file](src/assets/translations) via Pull Request.
 
 You can also provide your own custom translations.
 
@@ -405,7 +405,7 @@ map.pm.setLang('customName', customTranslation, 'en');
 ```
 
 The 3rd parameter is the fallback language in case you only want to override a few Strings.
-See the english translation file for all available strings.
+See the [english translation file](src/assets/translations/en.json) for all available strings.
 
 ##### Customize Style
 

--- a/README.md
+++ b/README.md
@@ -392,6 +392,23 @@ map.pm.setLang('de');
 Currently available languages are `de` and `en`.
 To add translations to the plugin, you can add [a translation file](https://github.com/codeofsumit/leaflet.pm/src/assets/translations) via Pull Request.
 
+You can also provide your own custom translations.
+
+```js
+map.pm.setLang(
+  'custom',
+  {
+    tooltips: {
+      placeMarker: 'Custom Marker Translation',
+    },
+  },
+  'en'
+);
+```
+
+The 3rd parameter is the fallback language in case you only want to override a few Strings.
+See the english translation file for all available strings.
+
 ##### Customize Style
 
 In order to change the style of the lines during draw, pass these options to the

--- a/README.md
+++ b/README.md
@@ -395,15 +395,13 @@ To add translations to the plugin, you can add [a translation file](https://gith
 You can also provide your own custom translations.
 
 ```js
-map.pm.setLang(
-  'custom',
-  {
-    tooltips: {
-      placeMarker: 'Custom Marker Translation',
-    },
+const customTranslation = {
+  tooltips: {
+    placeMarker: 'Custom Marker Translation',
   },
-  'en'
-);
+};
+
+map.pm.setLang('customName', customTranslation, 'en');
 ```
 
 The 3rd parameter is the fallback language in case you only want to override a few Strings.

--- a/cypress/integration/tooltips.spec.js
+++ b/cypress/integration/tooltips.spec.js
@@ -3,6 +3,17 @@ describe('Shows Tooltips', () => {
 
   const mapSelector = '#map';
 
+  it('Has Working Translations', () => {
+    cy.window().then(({ L }) => {
+      L.PM.activeLang = 'de';
+    });
+
+    cy.toolbarButton('polygon').click();
+    cy.get('.leaflet-tooltip-bottom').then(el => {
+      expect(el).to.have.text('Platziere den ersten Marker mit Klick');
+    });
+  });
+
   it('Has Marker Tooltips', () => {
     cy.get('.leaflet-tooltip-bottom').should('not.exist');
     cy.toolbarButton('marker').click();

--- a/cypress/integration/tooltips.spec.js
+++ b/cypress/integration/tooltips.spec.js
@@ -15,15 +15,13 @@ describe('Shows Tooltips', () => {
   });
   it('Supports Custom Translations', () => {
     cy.window().then(({ map }) => {
-      map.pm.setLang(
-        'custom',
-        {
-          tooltips: {
-            placeMarker: 'Custom Marker Translation',
-          },
+      const customTranslation = {
+        tooltips: {
+          placeMarker: 'Custom Marker Translation',
         },
-        'en'
-      );
+      };
+
+      map.pm.setLang('customName', customTranslation, 'en');
     });
 
     cy.toolbarButton('marker').click();

--- a/cypress/integration/tooltips.spec.js
+++ b/cypress/integration/tooltips.spec.js
@@ -3,7 +3,7 @@ describe('Shows Tooltips', () => {
 
   const mapSelector = '#map';
 
-  it.only('Has Working Translations', () => {
+  it('Has Working Translations', () => {
     cy.window().then(({ map }) => {
       map.pm.setLang('de');
     });
@@ -11,6 +11,24 @@ describe('Shows Tooltips', () => {
     cy.toolbarButton('polygon').click();
     cy.get('.leaflet-tooltip-bottom').then(el => {
       expect(el).to.have.text('Platziere den ersten Marker mit Klick');
+    });
+  });
+  it('Supports Custom Translations', () => {
+    cy.window().then(({ map }) => {
+      map.pm.setLang(
+        'custom',
+        {
+          tooltips: {
+            placeMarker: 'Custom Marker Translation',
+          },
+        },
+        'en'
+      );
+    });
+
+    cy.toolbarButton('marker').click();
+    cy.get('.leaflet-tooltip-bottom').then(el => {
+      expect(el).to.have.text('Custom Marker Translation');
     });
   });
 

--- a/cypress/integration/tooltips.spec.js
+++ b/cypress/integration/tooltips.spec.js
@@ -3,9 +3,9 @@ describe('Shows Tooltips', () => {
 
   const mapSelector = '#map';
 
-  it('Has Working Translations', () => {
-    cy.window().then(({ L }) => {
-      L.PM.activeLang = 'de';
+  it.only('Has Working Translations', () => {
+    cy.window().then(({ map }) => {
+      map.pm.setLang('de');
     });
 
     cy.toolbarButton('polygon').click();

--- a/src/assets/translations/de.json
+++ b/src/assets/translations/de.json
@@ -1,0 +1,7 @@
+{
+  "tooltips": {
+    "firstVertex": "Platziere den ersten Marker mit Klick"
+  },
+  "actions": {},
+  "buttonTitles": {}
+}

--- a/src/assets/translations/de.json
+++ b/src/assets/translations/de.json
@@ -1,7 +1,28 @@
 {
   "tooltips": {
-    "firstVertex": "Platziere den ersten Marker mit Klick"
+    "placeMarker": "Platziere den Marker mit Klick",
+    "firstVertex": "Platziere den ersten Marker mit Klick",
+    "continueLine": "Klicke, um weiter zu malen",
+    "finishLine": "Beende mit Klick auf existierenden Marker",
+    "finishPoly": "Beende mit Klick auf ersten Marker",
+    "finishRect": "Beende mit Klick",
+    "startCircle": "Platziere das Kreiszentrum mit Klick",
+    "finishCircle": "Beende den Kreis mit Klick"
   },
-  "actions": {},
-  "buttonTitles": {}
+  "actions": {
+    "finish": "Beenden",
+    "cancel": "Abbrechen",
+    "removeLastVertex": "Letzten Vertex löschen"
+  },
+  "buttonTitles": {
+    "drawMarkerButton": "Marker malen",
+    "drawPolyButton": "Polygons malen",
+    "drawLineButton": "Polyline malen",
+    "drawCircleButton": "Kreis malen",
+    "drawRectButton": "Rechteck malen",
+    "editButton": "Layers editieren",
+    "dragButton": "Layers bewegen",
+    "cutButton": "Layers schneiden",
+    "deleteButton": "Layers löschen"
+  }
 }

--- a/src/assets/translations/en.json
+++ b/src/assets/translations/en.json
@@ -1,7 +1,26 @@
 {
   "tooltips": {
-    "firstVertex": "Click to place the first vertex"
+    "firstVertex": "Click to place first vertex",
+    "continueLine": "Click to continue drawing",
+    "finishLine": "Click any existing marker to finish",
+    "finishPoly": "Click first marker to finish",
+    "finishRect": "Click to finish",
+    "finishCircle": "Click to finish circle"
   },
-  "actions": {},
-  "buttonTitles": {}
+  "actions": {
+    "finish": "Finish",
+    "cancel": "Cancel",
+    "removeLastVertex": "Remove Last Vertex"
+  },
+  "buttonTitles": {
+    "drawMarkerButton": "Draw Marker",
+    "drawPolyButton": "Draw Polygons",
+    "drawLineButton": "Draw Polyline",
+    "drawCircleButton": "Draw Circle",
+    "drawRectButton": "Draw Rectangle",
+    "editButton": "Edit Layers",
+    "dragButton": "Drag Layers",
+    "cutButton": "Cut Layers",
+    "deleteButton": "Remove Layers"
+  }
 }

--- a/src/assets/translations/en.json
+++ b/src/assets/translations/en.json
@@ -1,0 +1,7 @@
+{
+  "tooltips": {
+    "firstVertex": "Click to place the first vertex"
+  },
+  "actions": {},
+  "buttonTitles": {}
+}

--- a/src/assets/translations/en.json
+++ b/src/assets/translations/en.json
@@ -1,10 +1,12 @@
 {
   "tooltips": {
+    "placeMarker": "Click to place marker",
     "firstVertex": "Click to place first vertex",
     "continueLine": "Click to continue drawing",
     "finishLine": "Click any existing marker to finish",
     "finishPoly": "Click first marker to finish",
     "finishRect": "Click to finish",
+    "startCircle": "Click to place circle center",
     "finishCircle": "Click to finish circle"
   },
   "actions": {

--- a/src/assets/translations/index.js
+++ b/src/assets/translations/index.js
@@ -1,0 +1,7 @@
+import en from './en.json';
+import de from './de.json';
+
+export default {
+  en,
+  de,
+};

--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -51,7 +51,7 @@ Draw.Circle = Draw.extend({
     // add tooltip to hintmarker
     if (this.options.tooltips) {
       this._hintMarker
-        .bindTooltip('Click to place circle center', {
+        .bindTooltip(getTranslation('tooltips.startCircle'), {
           permanent: true,
           offset: L.point(0, 10),
           direction: 'bottom',

--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -1,5 +1,7 @@
 import Draw from './L.PM.Draw';
 
+import { getTranslation } from '../helpers';
+
 Draw.Circle = Draw.extend({
   initialize(map) {
     this._map = map;
@@ -180,7 +182,9 @@ Draw.Circle = Draw.extend({
       this._hintMarker.on('move', this._syncHintLine, this);
       this._hintMarker.on('move', this._syncCircleRadius, this);
 
-      this._hintMarker.setTooltipContent('Click to finish circle');
+      this._hintMarker.setTooltipContent(
+        getTranslation('tooltips.finishCircle')
+      );
 
       this._layer.fire('pm:centerplaced', {
         shape: this._shape,

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -1,6 +1,8 @@
 import kinks from '@turf/kinks';
 import Draw from './L.PM.Draw';
 
+import { getTranslation } from '../helpers';
+
 Draw.Line = Draw.extend({
   initialize(map) {
     this._map = map;
@@ -50,7 +52,7 @@ Draw.Line = Draw.extend({
     // add tooltip to hintmarker
     if (this.options.tooltips) {
       this._hintMarker
-        .bindTooltip('Click to place first vertex', {
+        .bindTooltip(getTranslation('tooltips.firstVertex'), {
           permanent: true,
           offset: L.point(0, 10),
           direction: 'bottom',

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -341,12 +341,14 @@ Draw.Line = Draw.extend({
 
     // handle tooltip text
     if (first) {
-      this._hintMarker.setTooltipContent('Click to continue drawing');
+      this._hintMarker.setTooltipContent(
+        getTranslation('tooltips.continueLine')
+      );
     }
     const second = this._layer.getLatLngs().length === 2;
 
     if (second) {
-      this._hintMarker.setTooltipContent('Click any existing marker to finish');
+      this._hintMarker.setTooltipContent(getTranslation('tooltips.finishLine'));
     }
 
     return marker;

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -1,5 +1,7 @@
 import Draw from './L.PM.Draw';
 
+import { getTranslation } from '../helpers';
+
 Draw.Marker = Draw.extend({
   initialize(map) {
     this._map = map;
@@ -28,7 +30,7 @@ Draw.Marker = Draw.extend({
     // add tooltip to hintmarker
     if (this.options.tooltips) {
       this._hintMarker
-        .bindTooltip('Click to place marker', {
+        .bindTooltip(getTranslation('tooltips.firstVertex'), {
           permanent: true,
           offset: L.point(0, 10),
           direction: 'bottom',

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -30,7 +30,7 @@ Draw.Marker = Draw.extend({
     // add tooltip to hintmarker
     if (this.options.tooltips) {
       this._hintMarker
-        .bindTooltip(getTranslation('tooltips.firstVertex'), {
+        .bindTooltip(getTranslation('tooltips.placeMarker'), {
           permanent: true,
           offset: L.point(0, 10),
           direction: 'bottom',

--- a/src/js/Draw/L.PM.Draw.Polygon.js
+++ b/src/js/Draw/L.PM.Draw.Polygon.js
@@ -1,5 +1,7 @@
 import Draw from './L.PM.Draw';
 
+import { getTranslation } from '../helpers';
+
 Draw.Polygon = Draw.Line.extend({
   initialize(map) {
     this._map = map;
@@ -76,12 +78,14 @@ Draw.Polygon = Draw.Line.extend({
 
     // handle tooltip text
     if (first) {
-      this._hintMarker.setTooltipContent('Click to continue drawing');
+      this._hintMarker.setTooltipContent(
+        getTranslation('tooltips.continueLine')
+      );
     }
     const third = this._layer.getLatLngs().length === 3;
 
     if (third) {
-      this._hintMarker.setTooltipContent('Click first marker to finish');
+      this._hintMarker.setTooltipContent(getTranslation('tooltips.finishPoly'));
     }
 
     return marker;

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -46,7 +46,7 @@ Draw.Rectangle = Draw.extend({
     // add tooltip to hintmarker
     if (this.options.tooltips) {
       this._hintMarker
-        .bindTooltip('Click to place first vertex', {
+        .bindTooltip(getTranslation('tooltips.firstVertex'), {
           permanent: true,
           offset: L.point(0, 10),
           direction: 'bottom',

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -1,5 +1,7 @@
 import Draw from './L.PM.Draw';
 
+import { getTranslation } from '../helpers';
+
 Draw.Rectangle = Draw.extend({
   initialize(map) {
     this._map = map;
@@ -165,7 +167,7 @@ Draw.Rectangle = Draw.extend({
     this._map.on('click', this._finishShape, this);
 
     // change tooltip text
-    this._hintMarker.setTooltipContent('Click to finish');
+    this._hintMarker.setTooltipContent(getTranslation('tooltips.finishRect'));
 
     this._setRectangleOrigin();
   },

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -1,3 +1,4 @@
+import merge from 'lodash/merge';
 import translations from '../assets/translations';
 
 const Map = L.Class.extend({
@@ -10,10 +11,7 @@ const Map = L.Class.extend({
   },
   setLang(lang = 'en', t, fallback = 'en') {
     if (t) {
-      translations[lang] = {
-        ...translations[fallback],
-        ...t,
-      };
+      translations[lang] = merge(translations[fallback], t);
     }
 
     L.PM.activeLang = lang;

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -1,3 +1,5 @@
+import translations from '../assets/translations';
+
 const Map = L.Class.extend({
   initialize(map) {
     this.map = map;
@@ -6,7 +8,14 @@ const Map = L.Class.extend({
 
     this._globalRemovalMode = false;
   },
-  setLang(lang = 'en') {
+  setLang(lang = 'en', t, fallback = 'en') {
+    if (t) {
+      translations[lang] = {
+        ...translations[fallback],
+        ...t,
+      };
+    }
+
     L.PM.activeLang = lang;
     this.map.pm.Toolbar.reinit();
   },

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -6,6 +6,10 @@ const Map = L.Class.extend({
 
     this._globalRemovalMode = false;
   },
+  setLang(lang = 'en') {
+    L.PM.activeLang = lang;
+    this.map.pm.Toolbar.reinit();
+  },
   addControls(options) {
     this.Toolbar.addControls(options);
   },

--- a/src/js/L.PM.js
+++ b/src/js/L.PM.js
@@ -31,11 +31,12 @@ import '../css/layers.css';
 import '../css/controls.css';
 
 L.PM = L.PM || {
+  version,
   Map,
   Toolbar,
   Draw,
   Edit,
-  version,
+  activeLang: 'en',
   initialize() {
     this.addInitHooks();
   },

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -1,3 +1,5 @@
+import { getTranslation } from '../helpers';
+
 const PMButton = L.Control.extend({
   options: {
     position: 'topleft',
@@ -80,19 +82,19 @@ const PMButton = L.Control.extend({
 
     const actions = {
       cancel: {
-        text: 'Cancel',
+        text: getTranslation('actions.cancel'),
         onClick() {
           this._triggerClick();
         },
       },
       removeLastVertex: {
-        text: 'Remove Last Vertex',
+        text: getTranslation('actions.removeLastVertex'),
         onClick() {
           this._map.pm.Draw[button.jsClass]._removeLastVertex();
         },
       },
       finish: {
-        text: 'Finish',
+        text: getTranslation('actions.finish'),
         onClick(e) {
           this._map.pm.Draw[button.jsClass]._finishShape(e);
         },

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -18,6 +18,19 @@ const Toolbar = L.Class.extend({
     position: 'topleft',
   },
   initialize(map) {
+    this.init(map);
+  },
+  reinit() {
+    const addControls = this.isVisible;
+
+    this.removeControls();
+    this._defineButtons();
+
+    if (addControls) {
+      this.addControls();
+    }
+  },
+  init(map) {
     this.map = map;
 
     this.buttons = {};

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -1,5 +1,7 @@
 import PMButton from './L.Controls';
 
+import { getTranslation } from '../helpers';
+
 L.Control.PMButton = PMButton;
 
 const Toolbar = L.Class.extend({
@@ -143,7 +145,7 @@ const Toolbar = L.Class.extend({
     // some buttons are still in their respective classes, like L.PM.Draw.Polygon
     const drawMarkerButton = {
       className: 'control-icon leaflet-pm-icon-marker',
-      title: 'Draw Marker',
+      title: getTranslation('buttonTitles.drawMarkerButton'),
       jsClass: 'Marker',
       onClick: () => {},
       afterClick: () => {
@@ -158,7 +160,7 @@ const Toolbar = L.Class.extend({
     };
 
     const drawPolyButton = {
-      title: 'Draw Polygon',
+      title: getTranslation('buttonTitles.drawPolyButton'),
       className: 'control-icon leaflet-pm-icon-polygon',
       jsClass: 'Polygon',
       onClick: () => {},
@@ -175,7 +177,7 @@ const Toolbar = L.Class.extend({
 
     const drawLineButton = {
       className: 'control-icon leaflet-pm-icon-polyline',
-      title: 'Draw Polyline',
+      title: getTranslation('buttonTitles.drawLineButton'),
       jsClass: 'Line',
       onClick: () => {},
       afterClick: () => {
@@ -190,7 +192,7 @@ const Toolbar = L.Class.extend({
     };
 
     const drawCircleButton = {
-      title: 'Draw Circle',
+      title: getTranslation('buttonTitles.drawCircleButton'),
       className: 'control-icon leaflet-pm-icon-circle',
       jsClass: 'Circle',
       onClick: () => {},
@@ -206,7 +208,7 @@ const Toolbar = L.Class.extend({
     };
 
     const drawRectButton = {
-      title: 'Draw Rectangle',
+      title: getTranslation('buttonTitles.drawRectButton'),
       className: 'control-icon leaflet-pm-icon-rectangle',
       jsClass: 'Rectangle',
       onClick: () => {},
@@ -222,7 +224,7 @@ const Toolbar = L.Class.extend({
     };
 
     const editButton = {
-      title: 'Edit Layers',
+      title: getTranslation('buttonTitles.editButton'),
       className: 'control-icon leaflet-pm-icon-edit',
       onClick: () => {},
       afterClick: () => {
@@ -237,7 +239,7 @@ const Toolbar = L.Class.extend({
     };
 
     const dragButton = {
-      title: 'Drag Layers',
+      title: getTranslation('buttonTitles.dragButton'),
       className: 'control-icon leaflet-pm-icon-drag',
       onClick: () => {},
       afterClick: () => {
@@ -252,7 +254,7 @@ const Toolbar = L.Class.extend({
     };
 
     const cutButton = {
-      title: 'Cut Layers',
+      title: getTranslation('buttonTitles.cutButton'),
       className: 'control-icon leaflet-pm-icon-cut',
       jsClass: 'Cut',
       onClick: () => {},
@@ -273,7 +275,7 @@ const Toolbar = L.Class.extend({
     };
 
     const deleteButton = {
-      title: 'Removal Mode',
+      title: getTranslation('buttonTitles.deleteButton'),
       className: 'control-icon leaflet-pm-icon-delete',
       onClick: () => {},
       afterClick: () => {

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -1,8 +1,15 @@
 import get from 'lodash/get';
+import has from 'lodash/has';
 import translations from '../../assets/translations';
 
 export function getTranslation(path) {
-  return get(translations[L.PM.activeLang], path);
+  let lang = L.PM.activeLang;
+
+  if (!has(translations, lang)) {
+    console.log('lang not found', lang);
+    lang = 'en';
+  }
+  return get(translations[lang], path);
 }
 
 export function isEmptyDeep(l) {

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -6,9 +6,9 @@ export function getTranslation(path) {
   let lang = L.PM.activeLang;
 
   if (!has(translations, lang)) {
-    console.log('lang not found', lang);
     lang = 'en';
   }
+
   return get(translations[lang], path);
 }
 

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -1,3 +1,10 @@
+import get from 'lodash/get';
+import translations from '../../assets/translations';
+
+export function getTranslation(path) {
+  return get(translations[L.PM.activeLang], path);
+}
+
 export function isEmptyDeep(l) {
   // thanks for the function, Felix Heck
   const flatten = list =>


### PR DESCRIPTION
Add translation files and custom configuration options to allow custom labels and translations for all user-facing copy inside leaflet.pm
Fixes #376.

- [x] Add Framework
- [x] Add German translation
- [x] Add Docs (incl call to action to create translation files)
- [x] Add custom translation API