### PR TITLE
Fixed snapIgnore condition check

### DIFF
--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -209,11 +209,10 @@ const SnapMixin = {
     // temporary markers of polygon-edits
     map.eachLayer(layer => {
       if (
-        layer instanceof L.Polyline ||
-        layer instanceof L.Marker ||
-        layer instanceof L.CircleMarker &&
+        (layer instanceof L.Polyline ||
+          layer instanceof L.Marker ||
+          layer instanceof L.CircleMarker) &&
         layer.options.snapIgnore !== true
-
       ) {
         layers.push(layer);
 


### PR DESCRIPTION
I suppose snapIgnore should apply for all layers instead of just CircleMarker